### PR TITLE
Download/Target Hash Improvement.

### DIFF
--- a/presqt/api_v1/serializers/target.py
+++ b/presqt/api_v1/serializers/target.py
@@ -16,6 +16,7 @@ class TargetsSerializer(serializers.Serializer):
     """
     name = serializers.CharField(max_length=256)
     supported_actions = SupportedActions()
+    supported_hash_algorithms = serializers.StringRelatedField(many=True)
     detail = serializers.SerializerMethodField()
 
     def get_detail(self, instance):
@@ -41,3 +42,4 @@ class TargetSerializer(serializers.Serializer):
     """
     name = serializers.CharField(max_length=256)
     supported_actions = SupportedActions()
+    supported_hash_algorithms = serializers.StringRelatedField(many=True)

--- a/presqt/api_v1/tests/views/target/test_target.py
+++ b/presqt/api_v1/tests/views/target/test_target.py
@@ -23,7 +23,7 @@ class TestTargetCollection(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # Verify that the first dictionary in the payload's array has the correct keys
-        expected_keys = ['name', 'supported_actions', 'detail']
+        expected_keys = ['name', 'supported_actions', 'supported_hash_algorithms', 'detail']
         expected_supported_keys = ['resource_collection', 'resource_detail', 'resource_download']
         for dict_item in response.data:
             self.assertListEqual(list(dict_item.keys()), expected_keys)

--- a/presqt/api_v1/tests/views/targets_test.json
+++ b/presqt/api_v1/tests/views/targets_test.json
@@ -5,6 +5,7 @@
           "resource_collection": false,
           "resource_detail": false,
           "resource_download": false
-    }
+    },
+    "supported_hash_algorithms": ["sha256", "md5"]
   }
 ]

--- a/presqt/api_v1/views/resource/resource.py
+++ b/presqt/api_v1/views/resource/resource.py
@@ -316,7 +316,7 @@ def download_resource(target_name, action, token, resource_id, ticket_path,
     write_file('{}/fixity_info.json'.format(base_directory), fixity_info, True)
 
     # Make a Bagit 'bag' of the resources.
-    bagit.make_bag(base_directory)
+    bagit.make_bag(base_directory, checksums=['md5', 'sha1', 'sha256', 'sha512'])
 
     # Zip the Bagit 'bag' to send forward.
     zip_directory(base_directory, "{}/{}.zip".format(ticket_path, base_file_name), ticket_path)

--- a/presqt/api_v1/views/target/target.py
+++ b/presqt/api_v1/views/target/target.py
@@ -31,6 +31,10 @@ class TargetCollection(APIView):
                     "resource_detail": true,
                     "resource_download": true
                 },
+                "supported_hash_algorithms": [
+                    "sha256",
+                    "md5"
+                ],
                 "detail": "http://localhost/api_v1/target/osf/"
             },
             {
@@ -40,6 +44,10 @@ class TargetCollection(APIView):
                     "resource_detail": true,
                     "resource_download": false
                 },
+                "supported_hash_algorithms": [
+                    "sha256",
+                    "md5"
+                ],
                 "detail": "http://localhost/api_v1/target/curate_nd/"
             },
             ...
@@ -79,7 +87,11 @@ class Target(APIView):
                 "resource_collection": true,
                 "resource_detail": true,
                 "resource_download": true
-            }
+            },
+            "supported_hash_algorithms": [
+                "sha256",
+                "md5"
+            ]
         }
 
         404: Not Found

--- a/presqt/json_schemas/target_schema.json
+++ b/presqt/json_schemas/target_schema.json
@@ -11,11 +11,18 @@
                 "resource_detail": {"type": "boolean"},
                 "resource_download": {"type": "boolean"}
             }
+        },
+        "supported_hash_algorithms": {
+            "type": "array",
+            "items": {
+            "type": "string"
+            }
         }
       },
       "required": [
         "name",
-        "supported_actions"
+        "supported_actions",
+        "supported_hash_algorithms"
       ]
     }
 }

--- a/presqt/targets.json
+++ b/presqt/targets.json
@@ -5,6 +5,7 @@
           "resource_collection": true,
           "resource_detail": true,
           "resource_download": true
-    }
+    },
+    "supported_hash_algorithms": ["sha256", "md5"]
   }
 ]


### PR DESCRIPTION
- Added 'supported_hash_algorithms' to Target JSON (and all necessary functionality to support this)
- Added all hash algorithms to BagIt creation for Downloads (md5, sha1, sha256, sha512).