### PR TITLE
Fix Metadata Bug

### DIFF
--- a/presqt/api_v1/utilities/metadata/upload_metadata.py
+++ b/presqt/api_v1/utilities/metadata/upload_metadata.py
@@ -38,6 +38,7 @@ def get_upload_source_metadata(instance, bag):
                 os.rename(metadata_path, invalid_metadata_path)
                 bag.save(manifests=True)
 
+
 def create_upload_metadata(instance, file_metadata_list, action_metadata, project_id,
                            resources_ignored, resources_updated):
     """

--- a/presqt/json_schemas/metadata_schema.json
+++ b/presqt/json_schemas/metadata_schema.json
@@ -11,8 +11,8 @@
           "actionType": { "type": "string" },
           "sourceTargetName": { "type": "string" },
           "destinationTargetName": { "type": ["string", "null"] },
-          "sourceUsername": { "type": ["string", "null"] },
-          "destinationUsername": { "type": ["string", "null"] },
+          "sourceUsername": { "type": ["string", "integer","null"] },
+          "destinationUsername": { "type": ["string", "integer", "null"] },
           "files": {
             "type": "object",
             "properties": {

--- a/presqt/targets/github/tests/views/resource/test_resource.py
+++ b/presqt/targets/github/tests/views/resource/test_resource.py
@@ -44,7 +44,8 @@ class TestResourceGETJSON(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         # Verify the dict keys match what we expect
         self.assertListEqual(self.keys, list(response.data.keys()))
-        self.assertListEqual(extra_keys, list(response.data['extra'].keys()))
+        for key in extra_keys:
+            self.assertIn(key, list(response.data['extra'].keys()))
         # Spot check some individual fields
         self.assertEqual('repo', response.data['kind_name'])
         self.assertEqual(resource_id, response.data['id'])


### PR DESCRIPTION
***Work Completed***
- Zenodo metadata had been causing issues with our metadata validator as they use number as identifiers
- Update JSON Schema
- Update tests

***Steps Required***
- N/A