### PR TITLE
Branks 42 Update GitHub urls

### DIFF
--- a/presqt/targets/github/utilities/helpers/create_repository.py
+++ b/presqt/targets/github/utilities/helpers/create_repository.py
@@ -21,8 +21,10 @@ def create_repository(title, token):
     token : str
         The users GitHub API token.
     """
+    header = {"Authorization": "token {}".format(token)}
     repository_payload = {"name": title}
-    response = requests.post('https://api.github.com/user/repos?access_token={}'.format(token),
+    response = requests.post('https://api.github.com/user/repos'.format(token),
+                             headers=header,
                              data=json.dumps(repository_payload))
 
     if response.status_code == 201:

--- a/presqt/targets/github/utilities/helpers/get_page_total.py
+++ b/presqt/targets/github/utilities/helpers/get_page_total.py
@@ -15,8 +15,9 @@ def get_page_total(token):
     -------
     The number of pages of repos the user has.
     """
-    user_url = 'https://api.github.com/user?access_token={}'.format(token)
-    user_data = requests.get(user_url).json()
+    header = {"Authorization": "token {}".format(token)}
+    user_url = 'https://api.github.com/user'
+    user_data = requests.get(user_url, headers=header).json()
     public_repos = user_data['public_repos']
     private_repos = user_data['total_private_repos']
     total_repos = public_repos + private_repos

--- a/presqt/targets/github/utilities/helpers/github_paginated_data.py
+++ b/presqt/targets/github/utilities/helpers/github_paginated_data.py
@@ -16,15 +16,15 @@ def github_paginated_data(token):
     -------
     List of all paginated data.
     """
-    base_url = "https://api.github.com/user/repos?access_token={}".format(token)
-    data = requests.get(base_url).json()
+    header = {"Authorization": "token {}".format(token)}
+    base_url = "https://api.github.com/user/repos"
+    data = requests.get(base_url, headers=header).json()
     page_total = get_page_total(token)
     # We want to start building urls from page 2 as we already have the data from page 1.
     page_count = 2
     while page_count <= page_total:
-        next_url = "https://api.github.com/user/repos?page={}&access_token={}".format(page_count,
-                                                                                      token)
-        next_data = requests.get(next_url).json()
+        next_url = "https://api.github.com/user/repos?page={}".format(page_count)
+        next_data = requests.get(next_url, headers=header).json()
         data.extend(next_data)
         page_count += 1
 


### PR DESCRIPTION
***Work Completed***
- Update all GitHub urls that used `access_token` as a query parameter as it is now deprecated
- Now use `Authorization` headers
- Ensure tests are still valid

***Steps Required***
- N/A

***Notes***
<img width="1157" alt="Screen Shot 2020-02-05 at 3 33 12 PM" src="https://user-images.githubusercontent.com/28787415/73880668-d6ef7680-482c-11ea-9d9b-0814b5461062.png">