### PR TITLE
Branks42 Cron Container

### DIFF
--- a/config/cron/crontabs/development.crontab
+++ b/config/cron/crontabs/development.crontab
@@ -1,0 +1,1 @@
+*/15 * * * * python /usr/src/app/manage.py delete_outdated_mediafiles

--- a/config/cron/crontabs/qa.crontab
+++ b/config/cron/crontabs/qa.crontab
@@ -1,0 +1,1 @@
+30 4 * * * python /usr/src/app/manage.py delete_outdated_mediafiles

--- a/cron.dockerfile
+++ b/cron.dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.7-alpine
+LABEL purpose "CRON Execution for PresQT jobs"
+
+ARG BUILD_ENVIRONMENT
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Specify environment variables that should be 
+# present inside of the container. Default them
+# to 'NA' if they are not available.
+ENV ENVIRONMENT=${ENVIRONMENT:-production}
+ENV DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-config.settings.${ENVIRONMENT}}
+
+WORKDIR /usr/local/etc
+COPY requirements requirements
+
+# Install System Level Dependencies
+# Installing client libraries and any other package you need
+RUN apk update && apk add libpq make
+
+# Installing build dependencies
+RUN apk add --virtual .build-deps gcc python-dev musl-dev postgresql-dev tzdata
+
+RUN cp /usr/share/zoneinfo/America/Indianapolis /etc/localtime
+RUN echo "America/Indianapolis" > /etc/timezone
+RUN apk del tzdata
+RUN pip install -r requirements/${BUILD_ENVIRONMENT}.txt
+
+# Delete build dependencies
+RUN apk del .build-deps
+
+WORKDIR /usr/src/app
+
+ADD config/cron/crontabs/${BUILD_ENVIRONMENT}.crontab /etc/crontabs/root
+
+ENTRYPOINT ["/usr/src/app/docker/cron_startup.sh"] 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,34 @@ services:
     volumes:
       - .:/usr/src/app
       - presqt_static_volume:/usr/src/app/staticfiles
+      - presqt_media_volume:/usr/src/app/mediafiles
     networks:
       - frontend
+      - backend
+  
+  # Since only one service should be running
+  # per container, we need something separate
+  # to run scheduled jobs.
+  presqt_cron:
+    restart: always
+    depends_on:
+      - presqt_django
+    build:
+      context: .
+      dockerfile: cron.dockerfile
+      args:
+        BUILD_ENVIRONMENT: ${ENVIRONMENT:-production}
+    environment:
+      CURATE_ND_TEST_TOKEN: $CURATE_ND_TEST_TOKEN
+      GITHUB_TEST_USER_TOKEN: $GITHUB_TEST_USER_TOKEN
+      SECRET_KEY: $SECRET_KEY
+      ENVIRONMENT: ${ENVIRONMENT:-production}
+      DJANGO_SETTINGS_MODULE: config.settings.${ENVIRONMENT:-production}
+    volumes:
+      - .:/usr/src/app
+      - presqt_static_volume:/usr/src/app/staticfiles
+      - presqt_media_volume:/usr/src/app/mediafiles
+    networks:
       - backend
 
 # We create two top-level networks to provide some isolation

--- a/docker/cron_startup.sh
+++ b/docker/cron_startup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# start cron
+/usr/sbin/crond -f -l 8

--- a/presqt/management/commands/delete_outdated_mediafiles.py
+++ b/presqt/management/commands/delete_outdated_mediafiles.py
@@ -15,9 +15,9 @@ class Command(BaseCommand):
         Delete all mediafiles that have run past their expiration date.
         """
         directories_list = [
-            'mediafiles/downloads/*/',
-            'mediafiles/uploads/*/',
-            'mediafiles/transfers/*/'
+            '/usr/src/app/mediafiles/downloads/*/',
+            '/usr/src/app/mediafiles/uploads/*/',
+            '/usr/src/app/mediafiles/transfers/*/'
         ]
         directories = []
         [directories.extend(glob(directory)) for directory in directories_list]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,5 @@
 Django==3.0.0
 gunicorn==19.9.0
-psycopg2==2.8.4
 pytz==2018.9
 requests==2.22.0
 jsonschema==3.0.1                   # An implementation of JSON Schema for Python

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 Django==3.0.0
 gunicorn==19.9.0
-psycopg2==2.7.6.1
+psycopg2==2.8.4
 pytz==2018.9
 requests==2.22.0
 jsonschema==3.0.1                   # An implementation of JSON Schema for Python


### PR DESCRIPTION
***Work Completed***
- mediafiles now save to volumes (Best Practice)
- Created cron container to run daily cleanup tasks
- Removed psycopg2 from requirements (Unnecessary)
- Add cron tasks to .crontab files to run every 15 minutes in development environments and at 4:30am daily on QA

***Steps Required***
- Rebuild docker, clean up mediafiles currently stored on the server