### PR TITLE
Branks42 Fix Curate Error

### DIFF
--- a/presqt/targets/curate_nd/classes/main.py
+++ b/presqt/targets/curate_nd/classes/main.py
@@ -34,7 +34,7 @@ class CurateND(CurateNDBase):
         response = requests.get('https://curate.nd.edu/api/items?editor=self',
                                 headers={'X-Api-Token': '{}'.format(token)})
         try:
-            response.json()['code']
+            response.json()['error']
         except KeyError:
             pass
         else:


### PR DESCRIPTION
***Work Completed***
- CurateND's api no longer has `code` in the payload if user is not authenticated
- Update to use `error`

***Steps Required***
- N/A