### PR TITLE
Branks42 Gitlab Deleted Projects

### DIFF
--- a/presqt/targets/gitlab/tests/views/resource/test_resource_collection.py
+++ b/presqt/targets/gitlab/tests/views/resource/test_resource_collection.py
@@ -154,6 +154,7 @@ class TestResourceCollection(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, [])
 
+
 class TestResourceCollectionPOST(SimpleTestCase):
     """
     Test the endpoint's POST method for resource uploads:


### PR DESCRIPTION
***Work Completed***
- GitLab does not handle deletions immediately, they hold onto the projects for a week before the deletion goes through.
- Do not display deleted projects on PresQT for GitLab

***Steps Required***
- N/A