### PR TITLE
Branks42 Add links to email messages

### DIFF
--- a/docs/target_integration.rst
+++ b/docs/target_integration.rst
@@ -392,7 +392,7 @@ Resource Upload Endpoint
 
     * The function must return a **dictionary** with the following keys:
 
-        ================== ===== =================================================================================
+        ================== ===== =========================================================================================
         resources_ignored  array Array of string paths of files that were ignored when uploading the resource
 
                                  Path should have the same base as resource_main_dir
@@ -402,7 +402,8 @@ Resource Upload Endpoint
         file_metadata_list list  List of dictionaries that contains FTS metadata and hash info for each file
         action_metadata    dict  Dictionary containing FTS metadata about the action occurring
         project_id         str   ID of the parent project for this upload. Needed for metadata upload
-        ================== ===== =================================================================================
+        project_link       str   The link to either the resource or the home page of the user if not available through API
+        ================== ===== =========================================================================================
 
         **Metadata Dictionary Details**
 
@@ -452,7 +453,8 @@ Resource Upload Endpoint
                     'resources_updated': resources_updated,
                     'action_metadata': action_metadata,
                     'file_metadata_list': file_metadata_list,
-                    'project_id': '1234'
+                    'project_id': '1234',
+                    'project_link': 'https://osf.io/1234'
                 }
 
 3. Add a function to upload FTS metadata to the correct location within the resource's parent project.

--- a/presqt/targets/figshare/functions/upload.py
+++ b/presqt/targets/figshare/functions/upload.py
@@ -59,7 +59,8 @@ def figshare_upload_resource(token, resource_id, resource_main_dir, hash_algorit
                                     "title": 'file_title',
                                     "destinationHash": {'hash_algorithm': 'the_hash'}}
                                 }
-        'project_id': ID of the parent project for this upload. Needed for metadata upload.
+        'project_id': ID of the parent project for this upload. Needed for metadata upload. 
+        'project_link': The link to either the resource or the home page of the user if not available through API
 
     FigShare's Upload Process
         1. Initiate new file upload (POST) within the article. Send file size, md5, and name but no file contents yet.
@@ -150,5 +151,6 @@ def figshare_upload_resource(token, resource_id, resource_main_dir, hash_algorit
         "resources_updated": resources_updated,
         "action_metadata": action_metadata,
         "file_metadata_list": file_metadata_list,
-        "project_id": "{}:{}".format(project_id, article_id)
+        "project_id": "{}:{}".format(project_id, article_id),
+        "project_link": "https://figshare.com/account/home#/projects"
     }

--- a/presqt/targets/github/functions/upload.py
+++ b/presqt/targets/github/functions/upload.py
@@ -56,6 +56,7 @@ def github_upload_resource(token, resource_id, resource_main_dir, hash_algorithm
                                     "destinationHash": {'hash_algorithm': 'the_hash'}}
                                 }
         'project_id': ID of the parent project for this upload. Needed for metadata upload.
+        'project_link': The link to either the resource or the home page of the user if not available through API
     """
     try:
         header, username = validation_check(token)
@@ -210,5 +211,6 @@ def github_upload_resource(token, resource_id, resource_main_dir, hash_algorithm
         'resources_updated': resources_updated,
         'action_metadata': action_metadata,
         'file_metadata_list': file_metadata_list,
-        'project_id': repo_id
+        'project_id': repo_id,
+        "project_link": "https://github.com/{}?tab=repositories".format(username)
     }

--- a/presqt/targets/gitlab/functions/upload.py
+++ b/presqt/targets/gitlab/functions/upload.py
@@ -57,6 +57,7 @@ def gitlab_upload_resource(token, resource_id, resource_main_dir, hash_algorithm
                                     "destinationHash": {'hash_algorithm': 'the_hash'}}
                                 }
         'project_id': ID of the parent project for this upload. Needed for metadata upload.
+        'project_link': The link to either the resource or the home page of the user if not available through API
     """
     base_url = "https://gitlab.com/api/v4/"
 
@@ -243,5 +244,6 @@ def gitlab_upload_resource(token, resource_id, resource_main_dir, hash_algorithm
         'resources_updated': resources_updated,
         'action_metadata': action_metadata,
         'file_metadata_list': file_metadata_list,
-        'project_id': project_id
+        'project_id': project_id,
+        'project_link': "https://gitlab.com/dashboard/projects"
     }

--- a/presqt/targets/osf/functions/upload.py
+++ b/presqt/targets/osf/functions/upload.py
@@ -59,6 +59,7 @@ def osf_upload_resource(token, resource_id, resource_main_dir,
                                     "destinationHash": {'hash_algorithm': 'the_hash'}}
                                 }
         'project_id': ID of the parent project for this upload. Needed for metadata upload.
+        'project_link': The link to either the resource or the home page of the user if not available through API
     """
     try:
         osf_instance = OSF(token)
@@ -138,5 +139,6 @@ def osf_upload_resource(token, resource_id, resource_main_dir,
         'resources_updated': resources_updated,
         'action_metadata': action_metadata,
         'file_metadata_list': file_metadata_list,
-        'project_id': project_id
+        'project_id': project_id,
+        "project_link": "https://osf.io/{}".format(project_id)
     }

--- a/presqt/targets/zenodo/functions/upload.py
+++ b/presqt/targets/zenodo/functions/upload.py
@@ -57,6 +57,7 @@ def zenodo_upload_resource(token, resource_id, resource_main_dir, hash_algorithm
                                     "destinationHash": {'hash_algorithm': 'the_hash'}}
                                 }
         'project_id': ID of the parent project for this upload. Needed for metadata upload.
+        'project_link': The link to either the resource or the home page of the user if not available through API
     """
     try:
         auth_parameter = zenodo_validation_check(token)
@@ -207,4 +208,5 @@ def zenodo_upload_loop(action_metadata, resource_id, resource_main_dir, post_url
         "action_metadata": action_metadata,
         "file_metadata_list": file_metadata_list,
         "project_id": resource_id,
+        "project_link": "https://zenodo.org/deposit?page=1&size=20"
     }


### PR DESCRIPTION
***Work Completed***
- Upload functions now include `project_link` in the returned dict
- This gets added so users can click to their uploaded or transferred resources from the email
- Update docs

***Steps Required***
- N/A