### PR TITLE
Branks42 Download Link for Email

### DIFF
--- a/presqt/api_v1/utilities/utils/send_email.py
+++ b/presqt/api_v1/utilities/utils/send_email.py
@@ -1,7 +1,7 @@
 from django.core.mail import send_mail, EmailMessage
 
 
-def transfer_upload_email_blaster(email_address, action, message):
+def email_blaster(email_address, action, message):
     """
     Function to send emails when a subprocess has finished running on the server.
 
@@ -18,6 +18,8 @@ def transfer_upload_email_blaster(email_address, action, message):
         title = "PresQT Upload Complete"
     elif action == 'resource_transfer_in':
         title = "PresQT Transfer Complete"
+    elif action == 'resource_download':
+        title = "PresQT Download Complete"
 
     send_mail(
         title,
@@ -25,27 +27,3 @@ def transfer_upload_email_blaster(email_address, action, message):
         'noreply@presqt.crc.nd.edu',
         [email_address],
         fail_silently=True)
-
-
-def download_email_blaster(email_address, file_path, message):
-    """
-    Function to send emails when a download has finished running on the server.
-
-    Parameters
-    ----------
-    email_address : str
-        The user's email address
-    file_path : bytes
-        The path to the zip file of downloaded items
-    message : str
-        The message to put in the body of the email
-    """
-    # Build the message
-    message = EmailMessage(
-        'PresQT Download Complete',
-        message,
-        'noreply@presqt.crc.nd.edu',
-        [email_address]
-    )
-    message.attach_file(file_path)
-    message.send(fail_silently=True)


### PR DESCRIPTION
***Work Completed***
- If a user leaves they page, they can now be emailed with a link to download their resource instead of attaching it to the email itself.
- New checks in job status
- Removed `download_email_blaster`

***Steps Required***
- N/A